### PR TITLE
update libring

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule Pogo.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:libring, "~> 1.6.0"},
+      {:libring, "~> 1.7.0"},
       {:local_cluster, "~> 1.2.1", only: [:test]},
       {:test_app, path: "test_app", only: [:test]},
       {:test_app_with_children, path: "test_app_with_children", only: [:test]},


### PR DESCRIPTION
Update libring to 1..7.0
1.6.0 is not working for us in our cluster. Everything hashes to the same node. But 1.7.0 fixes that...