### PR TITLE
fix: do not crash distributed supervisor when a child fails to start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.1
+
+* Do not crash the distributed supervisor when a child fails to start. `Supervisor.start_child/2` returns other than `{:ok, pid}` (e.g. `{:error, {:already_started, pid}}` on stale process-group state, or `{:error, reason}`/`:ignore` when a child init fails) are now handled: an already-started child is adopted, a transient failure is logged and retried on the next sync, and other children on the node are left untouched. https://github.com/team-telnyx/pogo/issues/4
+
 ## 0.3.0
 
 * Accept list of children to be started when supervisor starts. https://github.com/team-telnyx/pogo/pull/1

--- a/lib/pogo/dynamic_supervisor.ex
+++ b/lib/pogo/dynamic_supervisor.ex
@@ -30,6 +30,8 @@ defmodule Pogo.DynamicSupervisor do
 
   use GenServer, type: :supervisor
 
+  require Logger
+
   @type option :: {:name, Supervised.name()}
   @type init_option ::
           Supervisor.init_option()
@@ -215,15 +217,14 @@ defmodule Pogo.DynamicSupervisor do
 
       cond do
         assigned_node == Node.self() ->
-          unless supervising?(scope, child_spec) do
-            {:ok, pid} = Supervisor.start_child(supervisor, child_spec)
-
-            track_supervisor(scope, child_spec)
-            track_pid(scope, child_spec, pid)
-            track_spec(scope, child_spec)
+          if supervising?(scope, child_spec) do
+            complete_request(scope, request)
+          else
+            case start_child(supervisor, scope, child_spec) do
+              :ok -> complete_request(scope, request)
+              :error -> :noop
+            end
           end
-
-          complete_request(scope, request)
 
         tracks_spec?(scope, child_spec, assigned_supervisor) ->
           complete_request(scope, request)
@@ -275,11 +276,7 @@ defmodule Pogo.DynamicSupervisor do
           # start it here, if it's not started yet and it's not being terminated
 
           unless terminating?(scope, id) || supervising?(scope, child_spec) do
-            {:ok, pid} = Supervisor.start_child(supervisor, child_spec)
-
-            track_supervisor(scope, child_spec)
-            track_pid(scope, child_spec, pid)
-            track_spec(scope, child_spec)
+            start_child(supervisor, scope, child_spec)
           end
 
         _ ->
@@ -342,6 +339,64 @@ defmodule Pogo.DynamicSupervisor do
         :error == fetch_child_spec(scope, id) do
       finish_terminate(scope, id)
     end
+  end
+
+  # Starts a child under the local supervisor and registers it cluster-wide.
+  #
+  # Supervisor.start_child/2 does not always return {:ok, pid}. A non-ok return
+  # must never crash the distributed supervisor, otherwise every child on the
+  # node is torn down with it (dangling calls), the children get rescheduled and
+  # duplicated across nodes, and the crash/restart churn leaks processes (high
+  # memory). Returns :ok when the child is started or already present (so the
+  # caller can complete the pending request), :error otherwise (request is left
+  # in place and retried on the next sync).
+  defp start_child(supervisor, scope, child_spec) do
+    case Supervisor.start_child(supervisor, child_spec) do
+      {:ok, pid} when is_pid(pid) ->
+        register_child(scope, child_spec, pid)
+        :ok
+
+      {:ok, pid, _info} when is_pid(pid) ->
+        register_child(scope, child_spec, pid)
+        :ok
+
+      {:error, {:already_started, pid}} when is_pid(pid) ->
+        # stale :pg state said we were not supervising it, adopt the running child
+        register_child(scope, child_spec, pid)
+        :ok
+
+      {:error, :already_present} ->
+        # child spec is kept by the local supervisor but not running, restart it
+        case Supervisor.restart_child(supervisor, child_spec.id) do
+          {:ok, pid} when is_pid(pid) ->
+            register_child(scope, child_spec, pid)
+            :ok
+
+          {:ok, pid, _info} when is_pid(pid) ->
+            register_child(scope, child_spec, pid)
+            :ok
+
+          other ->
+            log_start_failure(child_spec, other)
+            :error
+        end
+
+      other ->
+        log_start_failure(child_spec, other)
+        :error
+    end
+  end
+
+  defp register_child(scope, child_spec, pid) do
+    track_supervisor(scope, child_spec)
+    track_pid(scope, child_spec, pid)
+    track_spec(scope, child_spec)
+  end
+
+  defp log_start_failure(%{id: id}, reason) do
+    Logger.error(
+      "Pogo.DynamicSupervisor failed to start child #{inspect(id)}: #{inspect(reason)}"
+    )
   end
 
   defp make_request(scope, request) do

--- a/lib/pogo/dynamic_supervisor.ex
+++ b/lib/pogo/dynamic_supervisor.ex
@@ -217,14 +217,7 @@ defmodule Pogo.DynamicSupervisor do
 
       cond do
         assigned_node == Node.self() ->
-          if supervising?(scope, child_spec) do
-            complete_request(scope, request)
-          else
-            case start_child(supervisor, scope, child_spec) do
-              :ok -> complete_request(scope, request)
-              :error -> :noop
-            end
-          end
+          start_assigned_child(scope, supervisor, child_spec, request)
 
         tracks_spec?(scope, child_spec, assigned_supervisor) ->
           complete_request(scope, request)
@@ -232,6 +225,14 @@ defmodule Pogo.DynamicSupervisor do
         true ->
           :noop
       end
+    end
+  end
+
+  defp start_assigned_child(scope, supervisor, child_spec, request) do
+    cond do
+      supervising?(scope, child_spec) -> complete_request(scope, request)
+      start_child(supervisor, scope, child_spec) == :ok -> complete_request(scope, request)
+      true -> :noop
     end
   end
 
@@ -351,46 +352,42 @@ defmodule Pogo.DynamicSupervisor do
   # caller can complete the pending request), :error otherwise (request is left
   # in place and retried on the next sync).
   defp start_child(supervisor, scope, child_spec) do
-    case Supervisor.start_child(supervisor, child_spec) do
-      {:ok, pid} when is_pid(pid) ->
-        register_child(scope, child_spec, pid)
-        :ok
+    supervisor
+    |> Supervisor.start_child(child_spec)
+    |> handle_start_result(supervisor, scope, child_spec)
+  end
 
-      {:ok, pid, _info} when is_pid(pid) ->
-        register_child(scope, child_spec, pid)
-        :ok
+  defp handle_start_result({:ok, pid}, _supervisor, scope, child_spec) when is_pid(pid) do
+    register_child(scope, child_spec, pid)
+  end
 
-      {:error, {:already_started, pid}} when is_pid(pid) ->
-        # stale :pg state said we were not supervising it, adopt the running child
-        register_child(scope, child_spec, pid)
-        :ok
+  defp handle_start_result({:ok, pid, _info}, _supervisor, scope, child_spec) when is_pid(pid) do
+    register_child(scope, child_spec, pid)
+  end
 
-      {:error, :already_present} ->
-        # child spec is kept by the local supervisor but not running, restart it
-        case Supervisor.restart_child(supervisor, child_spec.id) do
-          {:ok, pid} when is_pid(pid) ->
-            register_child(scope, child_spec, pid)
-            :ok
+  # stale :pg state said we were not supervising it, adopt the running child
+  defp handle_start_result({:error, {:already_started, pid}}, _supervisor, scope, child_spec)
+       when is_pid(pid) do
+    register_child(scope, child_spec, pid)
+  end
 
-          {:ok, pid, _info} when is_pid(pid) ->
-            register_child(scope, child_spec, pid)
-            :ok
+  # child spec is kept by the local supervisor but not running, restart it
+  defp handle_start_result({:error, :already_present}, supervisor, scope, child_spec) do
+    supervisor
+    |> Supervisor.restart_child(child_spec.id)
+    |> handle_start_result(supervisor, scope, child_spec)
+  end
 
-          other ->
-            log_start_failure(child_spec, other)
-            :error
-        end
-
-      other ->
-        log_start_failure(child_spec, other)
-        :error
-    end
+  defp handle_start_result(other, _supervisor, _scope, child_spec) do
+    log_start_failure(child_spec, other)
+    :error
   end
 
   defp register_child(scope, child_spec, pid) do
     track_supervisor(scope, child_spec)
     track_pid(scope, child_spec, pid)
     track_spec(scope, child_spec)
+    :ok
   end
 
   defp log_start_failure(%{id: id}, reason) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Pogo.MixProject do
   def project do
     [
       app: :pogo,
-      version: "0.3.0",
+      version: "0.3.1",
       elixir: "~> 1.11",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/pogo/dynamic_supervisor_test.exs
+++ b/test/pogo/dynamic_supervisor_test.exs
@@ -377,10 +377,32 @@ defmodule Pogo.DynamicSupervisorTest do
     end
   end
 
+  test "does not crash the supervisor when a child fails to start" do
+    [node] = start_nodes(:test_app, "foo", 1)
+
+    distributed_supervisor = :rpc.call(node, Process, :whereis, [@supervisor])
+    assert is_pid(distributed_supervisor)
+
+    # this child can never start, its init returns {:stop, _}
+    start_child(node, Pogo.FailingWorker.child_spec(1))
+
+    # a healthy child requested afterwards must still come up, which can only
+    # happen if the failed start above did not bring the supervisor down
+    start_child(node, Pogo.Worker.child_spec(2))
+
+    assert_async do
+      assert [{{Pogo.Worker, 2}, _, :worker, _}] =
+               :rpc.call(node, Pogo.DynamicSupervisor, :which_children, [@supervisor, :local])
+    end
+
+    # same supervisor process is still running, it was never restarted
+    assert :rpc.call(node, Process, :whereis, [@supervisor]) == distributed_supervisor
+  end
+
   defp start_nodes(app, prefix, n) do
     LocalCluster.start_nodes(prefix, n,
       applications: [app],
-      files: ["test/support/pogo/worker.ex"]
+      files: ["test/support/pogo/worker.ex", "test/support/pogo/failing_worker.ex"]
     )
   end
 

--- a/test/support/pogo/failing_worker.ex
+++ b/test/support/pogo/failing_worker.ex
@@ -1,0 +1,26 @@
+defmodule Pogo.FailingWorker do
+  @moduledoc false
+
+  # Test worker whose init fails on demand. Used to verify that a child failing
+  # to start does not crash the Pogo.DynamicSupervisor and take every other
+  # child down with it.
+
+  use GenServer
+
+  def child_spec(id) do
+    %{
+      id: {__MODULE__, id},
+      start: {__MODULE__, :start_link, [id]},
+      restart: :temporary
+    }
+  end
+
+  def start_link(id) do
+    GenServer.start_link(__MODULE__, id)
+  end
+
+  @impl true
+  def init(_id) do
+    {:stop, :always_fails}
+  end
+end


### PR DESCRIPTION
## Problem

`Pogo.DynamicSupervisor` hard-matches `{:ok, pid} = Supervisor.start_child(...)` in two places (`process_start_child_requests` and `distribute_children`). `Supervisor.start_child/2` does not always return `{:ok, pid}`:

- `{:error, {:already_started, pid}}` when the local one_for_one supervisor still holds the child but the `:pg`-based `supervising?/2` check says otherwise (stale process-group state after a crash, netsplit or rebalance).
- `{:error, reason}` / `:ignore` when the child's `init` fails or raises.

On any non-ok return the whole distributed supervisor GenServer crashes, taking every child on the node down with it. This is the root cause behind TELBACK-231 / issue #4: probers are torn down (dangling calls), rescheduled and duplicated across nodes after the restart (duplicate calls), and the crash/restart churn leaks processes (high memory).

## Fix

Single `start_child/3` helper that handles every return shape deterministically:

- `{:ok, pid}` / `{:ok, pid, info}` — track and register as before.
- `{:error, {:already_started, pid}}` — adopt the running child, register it, do not crash.
- `{:error, :already_present}` — restart the kept-but-stopped child.
- anything else — log and return `:error`; the pending request is left in place and retried on the next sync. Other children are untouched.

## Tests

Added a single-node regression test that starts a child whose `init` fails, then asserts the distributed supervisor stays alive and a healthy child requested afterwards still starts. It fails on `master` (the failed start crashes the supervisor, the healthy child never comes up) and passes with this change.

## Linear
https://linear.app/telnyx/issue/TELBACK-231

Closes #4
